### PR TITLE
Fix bug when collapse=FALSE

### DIFF
--- a/R/rate.mat.maker.R
+++ b/R/rate.mat.maker.R
@@ -465,14 +465,15 @@ getStateMat4Dat <- function(data, model = "ARD", dual = FALSE, collapse = TRUE, 
       rate.mat[rate.mat > 0] <- 1:length(rate.mat[rate.mat > 0])
     }
   }
-
-  colnames(rate.mat) <- rownames(rate.mat) <- paste("(", 1:nObs, ")", sep ="")
+  ## Caetano (May 4, 2023): Changing colnames below to fix when collapse == FALSE
   if(collapse){
+    colnames(rate.mat) <- rownames(rate.mat) <- paste("(", 1:nObs, ")", sep ="")
     legend <- CorData$ObservedTraits
     names(legend) <- 1:nObs
   }else{
+    colnames(rate.mat) <- rownames(rate.mat) <- paste("(", 1:ncol(rate.mat), ")", sep ="")
     legend <- CorData$PossibleTraits
-    names(legend) <- 1:nObs
+    names(legend) <- 1:ncol(rate.mat)
   }
   res <- list(legend = legend, rate.mat = rate.mat)
   return(res)


### PR DESCRIPTION
This fix a bug with getStateMat4Dat when collapse=FALSE and there are unobserved states.